### PR TITLE
Fix detect accuracy

### DIFF
--- a/.github/workflows/blackduck.yaml
+++ b/.github/workflows/blackduck.yaml
@@ -3,6 +3,9 @@ name: Black Duck scan
 on:
   schedule:
     - cron: 45 4 15 * *
+  push:
+    branches:
+      - detect_accuracy
   workflow_dispatch:
 
 jobs:
@@ -22,4 +25,4 @@ jobs:
           blackducksca_url: https://apus-blackduck.volvocars.biz
           blackducksca_token: ${{ secrets.BLACKDUCK_TOKEN }}
           detect_search_depth: 3
-          detect_args: '--detect.blackduck.signature.scanner.copyright.search=true --detect.blackduck.signature.scanner.snippet.matching=SNIPPET_MATCHING --detect.timeout=3000'
+          detect_args: '--detect.blackduck.signature.scanner.copyright.search=true --detect.blackduck.signature.scanner.snippet.matching=SNIPPET_MATCHING --detect.timeout=3000 --detect.accuracy.required=NONE'

--- a/.github/workflows/blackduck.yaml
+++ b/.github/workflows/blackduck.yaml
@@ -3,9 +3,6 @@ name: Black Duck scan
 on:
   schedule:
     - cron: 45 4 15 * *
-  push:
-    branches:
-      - detect_accuracy
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Why do I want to contribute this?

Solves FAILURE_ACCURACY_NOT_MET issues which would fail Blackduck scans whenever detector accuracy level is LOW. Setting detect_accuracy_required=NONE allows us to workaround [detectors](https://documentation.blackduck.com/bundle/detect/page/components/detectors.html) that only have LOW accuracy. 

---

- [x] This PR is linked to an issue **or** explains its purpose
- [x] This PR does not impact security
- [x] This PR does not impact functional safety (leave unchecked if unsure)
